### PR TITLE
Skip Install-ALCops outside GitHub Actions

### DIFF
--- a/scripts/Install-ALCops.ps1
+++ b/scripts/Install-ALCops.ps1
@@ -32,6 +32,12 @@ Param(
     [string] $copsFolder
 )
 
+# Exit immediately when not running in GitHub Actions.
+$githubActionsValue = $ENV:GITHUB_ACTIONS
+if ([string]::IsNullOrWhiteSpace($githubActionsValue) -or ($githubActionsValue.Trim().ToLowerInvariant() -eq "false")) {
+    return
+}
+
 $ErrorActionPreference = "Stop"
 $ScriptVersion = "1.0.0"
 


### PR DESCRIPTION
## Summary
This PR prevents Install-ALCops.ps1 from running outside GitHub Actions.

When using localDevEnv.ps1 in AL-Go with a PipelineInitialize.ps1 override, the install script could also be invoked locally. In that scenario, GITHUB_WORKSPACE is not set, which causes Join-Path to fail.

## Problem
- localDevEnv.ps1 can trigger the same initialization path as CI in certain override setups.
- Install-ALCops.ps1 assumes CI environment variables are present.
- Outside GitHub Actions, GITHUB_WORKSPACE may be null or empty.
- As a result, path construction fails and local setup breaks.

## Root Cause
The script executed unconditionally and attempted to resolve defaults using CI-only environment variables.

## What Changed
- Added an early guard at the start of Install-ALCops.ps1.
- The script now exits immediately when GITHUB_ACTIONS is:
  - null or empty
  - explicitly false (case-insensitive)

## Behavior After Change
- In GitHub Actions:
  - Script continues as before and installs analyzer DLLs.
- In local/non-CI environments:
  - Script exits without side effects.
  - No download, extraction, or folder/path operations are performed.

## Why This Fix
- Keeps CI behavior unchanged.
- Prevents local development failures caused by missing CI variables.
- Makes the script safe when reused through shared initialization paths.

## Notes
PR Description by AI, code change by human ;-)