### PR TITLE
feat: deprecate Install-ALCops.ps1 in favor of @alcops/core CLI

### DIFF
--- a/scripts/Install-ALCops.ps1
+++ b/scripts/Install-ALCops.ps1
@@ -39,9 +39,13 @@ if ([string]::IsNullOrWhiteSpace($githubActionsValue) -or ($githubActionsValue.T
 }
 
 $ErrorActionPreference = "Stop"
-$ScriptVersion = "1.0.1"
+$ScriptVersion = "1.0.2"
 
 Write-Host "Install-ALCops v$ScriptVersion"
+
+Write-Warning "Install-ALCops.ps1 is deprecated and will be removed in a future release."
+Write-Warning "Please migrate to the CLI-based approach using @alcops/core."
+Write-Warning "Migration guide: https://alcops.dev/docs/getting-started/cicd/github/#2-create-the-initialization-script"
 
 # ── Resolve defaults ─────────────────────────────────────────────────
 if (-not $packageName) {


### PR DESCRIPTION
## Summary

`Install-ALCops.ps1` is now deprecated. This PR adds visible `Write-Warning` messages directing users to migrate to the CLI-based approach using `@alcops/core`.

## What changed

- Added deprecation warnings (rendered yellow in GitHub Actions logs and shown in the annotations panel)
- Bumped script version to 1.0.2
- **No functional changes**: the script continues to work as before

## Migration

Users should follow the guide at:
https://alcops.dev/docs/getting-started/cicd/github/#2-create-the-initialization-script